### PR TITLE
return live and disconnected hyperties

### DIFF
--- a/server/specs/hyperties_spec.rb
+++ b/server/specs/hyperties_spec.rb
@@ -486,18 +486,18 @@ describe 'domain registry api tests' do
         expect_json_sizes(2)
       end
 
-      it 'should return one live hyperty, the other two are disconnected' do
+      it 'should return one live and two disconnected hyperties' do
         put host << '/hyperty/user/user%3A%2F%2Fgoogle.com%2Frui.jose@gmail.com/live_1', @live_1
         get host << '/hyperty/email/rui.jose@gmail.com'
         expect_status(200);
-        expect_json_sizes(1)
+        expect_json_sizes(3)
       end
 
-      it 'should return two live hyperty, after on of the disconnected comes back alive' do
+      it 'should return two live and one disconnected hyperties, after on of the disconnected comes back alive' do
         put host << '/hyperty/url/disconnected1', {}
         get host << '/hyperty/email/rui.jose@gmail.com'
         expect_status(200);
-        expect_json_sizes(2)
+        expect_json_sizes(3)
       end
 
       it 'should return three live hyperty, after the remaining disconnected comes back alive' do

--- a/server/src/main/java/domainregistry/HypertyService.java
+++ b/server/src/main/java/domainregistry/HypertyService.java
@@ -56,7 +56,8 @@ public class HypertyService{
         }
 
         if(connectionClient.userExists(userID) && !allUserHyperties.isEmpty()){
-            return liveHyperties(hypertiesWithStatusUpdated);
+            //return liveHyperties(hypertiesWithStatusUpdated);
+            return hypertiesWithStatusUpdated;
         }
 
         else throw new UserNotFoundException();
@@ -80,7 +81,8 @@ public class HypertyService{
             return hypertiesWithStatusUpdated;
         }
 
-        return liveHyperties(hypertiesWithStatusUpdated);
+        //return liveHyperties(hypertiesWithStatusUpdated);
+        return hypertiesWithStatusUpdated;
     }
 
     public Map<String, HypertyInstance> getHypertiesByEmail(Connection connectionClient, String email) {
@@ -101,7 +103,8 @@ public class HypertyService{
         if(allHypertiesAreUnavailable(hyperties))
             return hyperties;
 
-        else return liveHyperties(hyperties);
+        // else return liveHyperties(hyperties);
+        else return hyperties;
     }
 
     // Status page shows all hyperties independent of the their status
@@ -246,7 +249,8 @@ public class HypertyService{
         if(allHypertiesAreUnavailable(foundHyperties))
             return foundHyperties;
 
-        else return liveHyperties(foundHyperties);
+        //else return liveHyperties(foundHyperties);
+        else return foundHyperties;
     }
 
     public Map<String, HypertyInstance> getSpecificHypertiesByEmail(Connection connectionClient, String email, Map<String, String> parameters){
@@ -271,7 +275,8 @@ public class HypertyService{
         if(allHypertiesAreUnavailable(foundHyperties))
             return foundHyperties;
 
-        else return liveHyperties(foundHyperties);
+        // else return liveHyperties(foundHyperties);
+        else return foundHyperties;
     }
 
     protected void deleteExpiredHyperties(Connection connectionClient, String userID){


### PR DESCRIPTION
Fix the filtering process over the requested objects.

Now, it is possible to get live and disconnected objects 